### PR TITLE
A diagnosic analyzer that warns about the use of virtual properties inside lambda expressions passed to Task-returning methods

### DIFF
--- a/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace TestHelper
 {
@@ -20,6 +22,9 @@ namespace TestHelper
         private static readonly MetadataReference SystemNetHttpReference =
             MetadataReference.CreateFromFile(typeof(HttpClient).Assembly.Location);
         private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        private static readonly MetadataReference TasksReference = MetadataReference.CreateFromFile(typeof(Task).Assembly.Location);
+        private static readonly MetadataReference ExpressionsReference = MetadataReference.CreateFromFile(typeof(Expression).Assembly.Location);
+        private static readonly MetadataReference GenericCollectionsReference = MetadataReference.CreateFromFile(typeof(List<>).Assembly.Location);
         private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
         private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
 
@@ -154,6 +159,9 @@ namespace TestHelper
                 .AddProject(projectId, TestProjectName, TestProjectName, language)
                 .AddMetadataReference(projectId, SystemNetHttpReference)
                 .AddMetadataReference(projectId, CorlibReference)
+                .AddMetadataReference(projectId, TasksReference)
+                .AddMetadataReference(projectId, ExpressionsReference)
+                .AddMetadataReference(projectId, GenericCollectionsReference)
                 .AddMetadataReference(projectId, SystemCoreReference)
                 .AddMetadataReference(projectId, CSharpSymbolsReference)
                 .AddMetadataReference(projectId, CodeAnalysisReference);

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/LazyLoadingAnalyzerTest.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/LazyLoadingAnalyzerTest.cs
@@ -54,6 +54,36 @@ namespace LazyLoadingPropertyAnalyzer.Test
             };
 
             VerifyCSharpDiagnostic(test, expected);
+
+            var fixedSource = @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace LazyLoadingPropertyAnalyzer.Test
+{
+    class WithVirtualInt
+    {
+        public virtual int A { get; set; }
+    }
+
+    class TestProgram
+    {
+        private static Task<int> GetSingleAsync(Expression<Func<int, bool>> whereClause)
+        {
+            return Task.FromResult(new List<int>());
+        }
+
+        static async Task TestMain()
+        {
+            WithVirtualInt obj = new WithVirtualInt{A = 5};
+            int objA = obj.A;
+            int a = await GetSingleAsync(i => i == objA);
+        }
+    }
+}";
+            VerifyCSharpFix(test, fixedSource, allowNewCompilerDiagnostics:true);
         }
 
         [TestMethod]
@@ -126,6 +156,36 @@ namespace ConsoleApp1
                     }
             };
             VerifyCSharpDiagnostic(test, expected);
+
+            var fixedSource = @"using System;
+using System.Threading.Tasks;
+using System.Linq.Expressions;
+
+namespace ConsoleApp1
+{
+    class WithVirtualInt
+    {
+        public virtual int A { get; set; }
+    }
+    class WithOther
+    {
+        public WithVirtualInt B { get; set; }
+    }
+    class Program
+    {
+        private static Task<int> GetSingleAsync(Expression<Func<int, bool>> whereClause)
+        {
+            return null;
+        }
+        public async Task Method()
+        {
+            WithOther b = new WithOther();
+            int bBA = b.B.A;
+            int a = await GetSingleAsync(i => 3 == bBA);
+        }
+    }
+}";
+            VerifyCSharpFix(test, fixedSource, allowNewCompilerDiagnostics:true);
         }
 
         [TestMethod]
@@ -169,11 +229,46 @@ namespace ConsoleApp1
                     }
             };
             VerifyCSharpDiagnostic(test, expected);
+
+            var fixedSource = @"using System;
+using System.Threading.Tasks;
+using System.Linq.Expressions;
+
+namespace ConsoleApp1
+{
+    class WithVirtual
+    {
+        public virtual WithOther A { get; set; }
+    }
+    class WithOther
+    {
+        public int B { get; set; }
+    }
+    class Program
+    {
+        private static Task<int> GetSingleAsync(Expression<Func<int, bool>> whereClause)
+        {
+            return Task.FromResult(0);
+        }
+        public async Task Method()
+        {
+            WithVirtual b = new WithVirtual { };
+            ConsoleApp1.WithOther bA = b.A;
+            int a = await GetSingleAsync(i => 5 == bA.B);
+        }
+    }
+}";
+            VerifyCSharpFix(test, fixedSource, allowNewCompilerDiagnostics:true);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new LazyLoadingPropertyAnalyzer();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new LazyLoadingPropertyCodeFixProvider();
         }
     }
 }

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/LazyLoadingAnalyzerTest.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/LazyLoadingAnalyzerTest.cs
@@ -13,7 +13,7 @@ namespace Analyzer1.Test
     public class LazyLoadingAnalyzerTest : CodeFixVerifier
     {
         [TestMethod]
-        public void TestLazyProperty()
+        public void TestLazyPropertyFromOuterScope()
         {
             var test = @"using System;
 using System.Collections.Generic;
@@ -54,6 +54,35 @@ namespace LazyLoadingPropertyAnalyzer.Test
             };
 
             VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void TestLazyProperty()
+        {
+            var test = @"using System;
+using System.Threading.Tasks;
+using System.Linq.Expressions;
+
+namespace ConsoleApp1
+{
+    class WithVirtualInt
+    {
+        public virtual int A { get; set; }
+    }
+    class Program
+    {
+        private static Task<WithVirtualInt> GetSingleAsync(Expression<Func<WithVirtualInt, bool>> whereClause)
+        {
+            return Task.FromResult<WithVirtualInt>(null);
+        }
+        public async Task Method()
+        {
+            WithVirtualInt a = await GetSingleAsync(i => i.A == 5);
+        }
+    }
+}";
+
+            VerifyCSharpDiagnostic(test);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/LazyLoadingAnalyzerTest.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1.Test/LazyLoadingAnalyzerTest.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestHelper;
+
+namespace Analyzer1.Test
+{
+    [TestClass]
+    public class LazyLoadingAnalyzerTest : CodeFixVerifier
+    {
+        [TestMethod]
+        public void TestLazyProperty()
+        {
+            var test = @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace LazyLoadingPropertyAnalyzer.Test
+{
+    class WithVirtualInt
+    {
+        public virtual int A { get; set; }
+    }
+
+    class TestProgram
+    {
+        private static Task<int> GetSingleAsync(Expression<Func<int, bool>> whereClause)
+        {
+            return Task.FromResult(new List<int>());
+        }
+
+        static async Task TestMain()
+        {
+            WithVirtualInt obj = new WithVirtualInt{A = 5};
+            int a = await GetSingleAsync(i => i == obj.A);
+        }
+    }
+}";
+            var expected = new DiagnosticResult
+            {
+                Id = "LazyEvaluationInExpression",
+                Message = "Property \"A\" might be loaded asynchronously when accessed during asynchronous evaluation in method \"GetSingleAsync\".",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[] {
+                        new DiagnosticResultLocation("Test0.cs", 24, 52)
+                    }
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new LazyLoadingPropertyAnalyzer();
+        }
+    }
+}

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Analyzer1
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class LazyLoadingPropertyAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "LazyLoadingPropertyAnalyzer";
+        // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
+        private const string Category = "Best practices";
+
+        private static DiagnosticDescriptor LazyEvaluationInExpressionRule = new DiagnosticDescriptor("LazyEvaluationInExpression", "Be careful about accessing virtual properties here", "Property \"{0}\" might be loaded asynchronously when accessed during asynchronous evaluation in method \"{1}\".", Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: "use of lazy-loaded property inside expression that is passed to asynchronous method");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(LazyEvaluationInExpressionRule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            // TODO: Consider registering other actions that act on syntax instead of or in addition to symbols
+            // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+            //context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+            context.RegisterOperationAction(AnalyzeOperation, OperationKind.Invocation);
+        }
+
+        private static void AnalyzeOperation(OperationAnalysisContext context)
+        {
+            IInvocationOperation operation = (IInvocationOperation)context.Operation;
+            if (!ReturnsTask(operation.TargetMethod))
+            {
+                return;
+            }
+            foreach (IArgumentOperation argument in operation.Arguments)
+            {
+                AnalyzeArgument(argument, context, operation.TargetMethod.Name);
+            }
+        }
+
+        private static void AnalyzeArgument(IArgumentOperation argument, OperationAnalysisContext context, string methodName)
+        {
+            if (!HasLambdaExpression(argument))
+            {
+                return;
+            }
+            FindAndAnalyzePropertyReference(argument, context, methodName);
+        }
+
+        private static void FindAndAnalyzePropertyReference(IOperation operation, OperationAnalysisContext context, string methodName)
+        {
+            if (operation.Kind == OperationKind.PropertyReference)
+            {
+                AnalyzePropertyReference((IPropertyReferenceOperation)operation, context, methodName);
+            }
+            else
+            {
+                foreach (IOperation childOperation in operation.Children)
+                {
+                    FindAndAnalyzePropertyReference(childOperation, context, methodName);
+                }
+            }
+        }
+
+        private static void AnalyzePropertyReference(IPropertyReferenceOperation operation, OperationAnalysisContext context, string methodName)
+        {
+            if (operation.Property.IsVirtual)
+            {
+                var diagnostic = Diagnostic.Create(LazyEvaluationInExpressionRule, operation.Syntax.GetLocation(), operation.Property.Name,
+                    methodName);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private static bool HasLambdaExpression(IArgumentOperation argument)
+        {
+            ArgumentSyntax syntax = argument.Syntax as ArgumentSyntax;
+            if (syntax == null)
+            {
+                return false;
+            }
+            LambdaExpressionSyntax lambdaSyntax = syntax.Expression as LambdaExpressionSyntax;
+            if (lambdaSyntax == null)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        private static bool ReturnsTask(IMethodSymbol method)
+        {
+            string returnType = method.ReturnType.ToString();
+            return returnType.Contains("System.Threading.Tasks.Task");
+        }
+    }
+}

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
@@ -65,7 +65,7 @@ namespace Analyzer1
 
         private static void AnalyzePropertyReference(IPropertyReferenceOperation operation, OperationAnalysisContext context, string methodName)
         {
-            if (operation.Property.IsVirtual)
+            if (operation.Property.IsVirtual && operation.Instance.Kind == OperationKind.LocalReference)
             {
                 var diagnostic = Diagnostic.Create(LazyEvaluationInExpressionRule, operation.Syntax.GetLocation(), operation.Property.Name,
                     methodName);

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
@@ -63,9 +63,23 @@ namespace Analyzer1
             }
         }
 
+        private static bool IsLocalReference(IOperation operation)
+        {
+            if (operation.Kind == OperationKind.LocalReference)
+            {
+                return true;
+            }
+            IPropertyReferenceOperation propertyReference = operation as IPropertyReferenceOperation;
+            if (propertyReference == null)
+            {
+                return false;
+            }
+            return IsLocalReference(propertyReference.Instance);
+        }
+
         private static void AnalyzePropertyReference(IPropertyReferenceOperation operation, OperationAnalysisContext context, string methodName)
         {
-            if (operation.Property.IsVirtual && operation.Instance.Kind == OperationKind.LocalReference)
+            if (operation.Property.IsVirtual && IsLocalReference(operation.Instance))
             {
                 var diagnostic = Diagnostic.Create(LazyEvaluationInExpressionRule, operation.Syntax.GetLocation(), operation.Property.Name,
                     methodName);

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
@@ -77,9 +77,28 @@ namespace Analyzer1
             return IsLocalReference(propertyReference.Instance);
         }
 
+        private static IPropertyReferenceOperation FindVirtualPropertyReference(IPropertyReferenceOperation operation)
+        {
+            if (operation.Property.IsVirtual)
+            {
+                return operation;
+            }
+            IPropertyReferenceOperation instancePropertyReference = operation.Instance as IPropertyReferenceOperation;
+            if (instancePropertyReference == null)
+            {
+                return null;
+            }
+            return FindVirtualPropertyReference(instancePropertyReference);
+        }
+
         private static void AnalyzePropertyReference(IPropertyReferenceOperation operation, OperationAnalysisContext context, string methodName)
         {
-            if (operation.Property.IsVirtual && IsLocalReference(operation.Instance))
+            operation = FindVirtualPropertyReference(operation);
+            if (operation == null)
+            {
+                return;
+            }
+            if (IsLocalReference(operation.Instance))
             {
                 var diagnostic = Diagnostic.Create(LazyEvaluationInExpressionRule, operation.Syntax.GetLocation(), operation.Property.Name,
                     methodName);

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyAnalyzer.cs
@@ -9,12 +9,12 @@ namespace Analyzer1
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class LazyLoadingPropertyAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "LazyLoadingPropertyAnalyzer";
+        public const string DiagnosticId = "LazyEvaluationInExpression";
         // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
         // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
         private const string Category = "Best practices";
 
-        private static DiagnosticDescriptor LazyEvaluationInExpressionRule = new DiagnosticDescriptor("LazyEvaluationInExpression", "Be careful about accessing virtual properties here", "Property \"{0}\" might be loaded asynchronously when accessed during asynchronous evaluation in method \"{1}\".", Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: "use of lazy-loaded property inside expression that is passed to asynchronous method");
+        private static DiagnosticDescriptor LazyEvaluationInExpressionRule = new DiagnosticDescriptor(DiagnosticId, "Be careful about accessing virtual properties here", "Property \"{0}\" might be loaded asynchronously when accessed during asynchronous evaluation in method \"{1}\".", Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: "use of lazy-loaded property inside expression that is passed to asynchronous method");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(LazyEvaluationInExpressionRule); } }
 

--- a/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyCodeFixProvider.cs
+++ b/HttpClientAnalyzer/Analyzer1/Analyzer1/LazyLoadingPropertyCodeFixProvider.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Analyzer1
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LazyLoadingPropertyCodeFixProvider)), Shared]
+    public class LazyLoadingPropertyCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get
+            {
+                return ImmutableArray.Create(LazyLoadingPropertyAnalyzer.DiagnosticId);
+            }
+        }
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            var root = await context.Document.GetSyntaxRootAsync();
+            var diagnosticNode = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie:true);
+            context.RegisterCodeFix(CodeAction.Create(
+                title: $"Initialize a local with the value of '{diagnosticNode.ToString()}'",
+                createChangedDocument:c => IntroduceLocal(context.Document, diagnosticNode)
+                ), diagnostic);
+        }
+
+        private static async Task<Document> IntroduceLocal(Document originalDocument, SyntaxNode diagnosticSyntaxNode)
+        {
+            ExpressionSyntax diagnosticExpression = diagnosticSyntaxNode as ExpressionSyntax;
+            if (diagnosticExpression == null)
+            {
+                return originalDocument;
+            }
+            SemanticModel model = await originalDocument.GetSemanticModelAsync();
+            IOperation diagnosticOperation = model.GetOperation(diagnosticSyntaxNode);
+            ITypeSymbol type = diagnosticOperation.Type;
+            string newVariableName = GetNewLocalName(model, diagnosticSyntaxNode);
+            LocalDeclarationStatementSyntax newLocal =
+                GetVariableDeclaration(type, newVariableName, diagnosticExpression);
+            ExpressionSyntax identifier = IdentifierName(newVariableName);
+            StatementSyntax methodInvocation = GetMethodInvocation(diagnosticSyntaxNode);
+            var editor = await DocumentEditor.CreateAsync(originalDocument);
+            editor.InsertBefore(methodInvocation, newLocal);
+            editor.ReplaceNode(diagnosticExpression, identifier);
+            return editor.GetChangedDocument();
+        }
+
+        private static StatementSyntax GetMethodInvocation(SyntaxNode diagnosticSyntaxNode)
+        {
+            return diagnosticSyntaxNode.FirstAncestorOrSelf<InvocationExpressionSyntax>()
+                .FirstAncestorOrSelf<StatementSyntax>();
+        }
+
+        private static string GetNewLocalName(SemanticModel model, SyntaxNode diagnosticSyntaxNode)
+        {
+            var localNames = model.LookupSymbols(diagnosticSyntaxNode.GetLocation().SourceSpan.Start)
+                .OfType<ILocalSymbol>()
+                .Select(s => s.ToString())
+                .ToList();
+            string newName = diagnosticSyntaxNode.ToString().Replace(".", "");
+            while (localNames.Contains(newName))
+            {
+                newName = "_" + newName;
+            }
+            return newName;
+        }
+
+        private static LocalDeclarationStatementSyntax GetVariableDeclaration(ITypeSymbol type, string name, ExpressionSyntax value)
+        {
+            return LocalDeclarationStatement(
+                VariableDeclaration(
+                    IdentifierName(type.ToString()))
+                .WithVariables(SingletonSeparatedList(
+                    VariableDeclarator(Identifier(name))
+                    .WithInitializer(EqualsValueClause(value))
+                    )));
+        }
+    }
+}


### PR DESCRIPTION
```cs
using System;
using System.Collections.Generic;
using System.Linq;
using System.Linq.Expressions;
using System.Threading.Tasks;

namespace MyNameSpace
{
    class WithVirtualInt
    {
        public virtual int A { get; set; }
    }

    class TestProgram
    {
        private static Task<int> GetSingleAsync(Expression<Func<int, bool>> whereClause)
        {
            // ...
        }

        static async Task TestMain()
        {
            WithVirtualInt obj = //...
            int a = await GetSingleAsync(i => i == obj.A); // <== warn about obj.A being accessed here
                                               // and offer to initialize a local with the value of
                                               // obj.A
        }
    }
}
```